### PR TITLE
Changes to upload to PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include README.textile
+include *.py
+recursive-include src/django_su *.py
+recursive-include src/django_su/templatetags *.py
+recursive-include src/django_su/templates *

--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,6 @@ setup(
     
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
+    include_package_data=True,
+    zip_safe=False,
 )


### PR DESCRIPTION
- With the option zip_safe=False you don't need uncomment the TEMPLATE_LOADERS 'django.template.loaders.eggs.Loader' [1]
- Without the manifest the egg has not the templates folder

REF's
1. https://code.djangoproject.com/browser/django/trunk/django/conf/global_settings.py#L187
