### PR TITLE
Minor templating fix

### DIFF
--- a/src/django_su/templates/su/login_link.html
+++ b/src/django_su/templates/su/login_link.html
@@ -1,7 +1,5 @@
 {% load i18n %}
 
 {% if can_su_login %}
-    <ul class="object-tools">
-        <li><a href="{% url su_login %}">{% trans "Login as other user" %}</a></li>
-    </ul>
+    <li><a href="{% url su_login %}">{% trans "Login as other user" %}</a></li>
 {% endif %}


### PR DESCRIPTION
This might well only apply in Django 1.4, but I was seeing a double-wrapping in <ul class="object-tools">. This patch should fix that issue.
