### PR TITLE
Remove deprecated adminmedia usage

### DIFF
--- a/src/django_su/templates/su/login.html
+++ b/src/django_su/templates/su/login.html
@@ -1,6 +1,6 @@
 {% extends "admin/base_site.html" %}
 
-{% load i18n adminmedia %}
+{% load i18n admin_static %}
 
 {% block extrahead %}
     {{ block.super }}
@@ -10,7 +10,7 @@
         <link href="{{ STATIC_URL }}css/ajax_select.css" rel="stylesheet" type="text/css" href="style.css" media="all" />
     {% endif %}
     {{ form.media }}
-    <link href="{% admin_media_prefix %}css/forms.css" type="text/css" rel="stylesheet">
+    <link href="{% static 'admin/css/forms.css' %}" type="text/css" rel="stylesheet">
 {% endblock %}
 
 


### PR DESCRIPTION
The 1.5 release of Django apparently deprecated adminmedia but did not remove it. [In 1.5.2 this is no longer true](https://docs.djangoproject.com/en/1.5/releases/1.5/#miscellaneous) and results in errors when the template tries to load it. admin_static is the recommended alternative.
