### PR TITLE
Fixed import error for django 1.6

### DIFF
--- a/src/django_su/urls.py
+++ b/src/django_su/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except ImportError:  # django < 1.4
+    from django.conf.urls.defaults import patterns, url
 
 
 urlpatterns = patterns("django_su.views",


### PR DESCRIPTION
urls.defaults was deprecated in django 1.4 and removed in 1.6. This is a backwards compatible change.
