### PR TITLE
Fix login_link template on django 1.4

### DIFF
--- a/src/django_su/templates/su/login_link.html
+++ b/src/django_su/templates/su/login_link.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load url from future %}
 
 {% if can_su_login %}
     <li><a href="{% url 'su_login' %}">{% trans "Login as other user" %}</a></li>


### PR DESCRIPTION
{% url 'su_login' %} syntax does not work on django 1.4
Loading url from future fix this
