### PR TITLE
No need for su when adding a new user

### DIFF
--- a/django_su/templates/admin/auth/user/change_form.html
+++ b/django_su/templates/admin/auth/user/change_form.html
@@ -4,14 +4,16 @@
 
 {% block object-tools-items %}
   {{ block.super }}
+  {% if object_id %}
   <li>
     <a href="javascript:void(0);" onclick="document.getElementById('suform').submit();" class="su">
       <i class="icon-user icon-alpha75"></i>{% trans "Login as" %}
     </a>
   </li>
+  {% endif %}
 {% endblock %}
 
 {% block content %}
   {{ block.super }}
-  <form id="suform" action="{% url 'login_as_user' object_id %}" method="POST">{% csrf_token %}</form>
+  {% if object_id %}<form id="suform" action="{% url 'login_as_user' object_id %}" method="POST">{% csrf_token %}</form>{% endif %}
 {% endblock %}


### PR DESCRIPTION
Avoids:
NoReverseMatch at /admin/auth/user/add/
Reverse for 'login_as_user' with arguments '(None,)' not found. 1 pattern(s) tried: ['su/(?P<user_id>-?[\\d]+)/$']