### PR TITLE
Consider: Add request to authenticate call

### DIFF
--- a/django_su/views.py
+++ b/django_su/views.py
@@ -20,7 +20,7 @@ from .utils import su_login_callback, custom_login_action
 @require_http_methods(['POST'])
 @user_passes_test(su_login_callback)
 def login_as_user(request, user_id):
-    userobj = authenticate(su=True, user_id=user_id)
+    userobj = authenticate(request=request, su=True, user_id=user_id)
     if not userobj:
         raise Http404("User not found")
 


### PR DESCRIPTION
Hello!

Recently, our team was attempting to implement rate limiting via Django-axes and ran into issues when using the `login_as_user` view. Django-axes requires that the optional `request` argument to be passed to `authenticate`. This optional argument was added on Django 1.11. 

This PR proposes adding the request to `login_as_user`. It allows Django-su to work with any custom authentication backends, such as Django-axes, without requiring any workarounds. It should not affect existing implementations of Django-su as well. In addition, this helps prepare for Django 2.1, where “Support for methods that don’t accept request as the first positional argument will be removed” [See Here.](https://docs.djangoproject.com/en/2.0/releases/1.11/) 

Thanks and awesome work!