### PR TITLE
Support custom logout actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,11 @@ There are various optional configuration options you can set in your ``settings.
     # Default: None
     SU_CUSTOM_LOGIN_ACTION = "example.utils.custom_login"
 
+    # A function to override the django.contrib.auth.login(request, user)
+    # view on logout. (django_su logs you in as the su'er on su_logout.)
+    # Default: SU_CUSTOM_LOGIN_ACTION
+    SU_CUSTOM_LOGOUT_ACTION = "example.utils.custom_logout"
+
 Usage
 -----
 

--- a/django_su/tests/test_views.py
+++ b/django_su/tests/test_views.py
@@ -246,3 +246,20 @@ class LogoutViewTestCase(SuViewsBaseTestCase):
             response = self.client.get(reverse('su_logout'))
         self.assertEqual(response.status_code, 302)
         self.assertTrue('/foo/bar' in response['Location'])
+
+    def test_custom_logout_action(self):
+        """Ensure custom logout action is called"""
+        self.client.login(username='authorized', password='pass')
+        response = self.client.post(
+            reverse('login_as_user', args=[self.destination_user.id])
+        )
+
+        flag = { 'called': False }
+        def custom_action(request, user):
+            flag['called'] = True
+
+        with self.settings(SU_CUSTOM_LOGOUT_ACTION=custom_action):
+            response = self.client.post(
+                reverse('su_logout')
+            )
+        self.assertTrue(flag['called'])

--- a/django_su/utils.py
+++ b/django_su/utils.py
@@ -32,3 +32,18 @@ def custom_login_action(request, user):
     func(request, user)
 
     return True
+
+
+def custom_logout_action(request, user):
+    func = getattr(settings, 'SU_CUSTOM_LOGOUT_ACTION', None)
+    if func is None:
+        # Backwards compatibility
+        func = getattr(settings, 'SU_CUSTOM_LOGIN_ACTION', None)
+        if func is None:
+            return False
+
+    if not isinstance(func, collections.Callable):
+        func = import_string(func)
+    func(request, user)
+
+    return True

--- a/django_su/views.py
+++ b/django_su/views.py
@@ -12,7 +12,7 @@ from django.http import HttpResponseBadRequest, HttpResponseRedirect, Http404
 from django.shortcuts import get_object_or_404, render
 
 from .forms import UserSuForm
-from .utils import su_login_callback, custom_login_action
+from .utils import su_login_callback, custom_login_action, custom_logout_action
 
 User = get_user_model()
 
@@ -76,7 +76,7 @@ def su_logout(request):
     userobj = get_object_or_404(User, pk=user_id)
     userobj.backend = backend
 
-    if not custom_login_action(request, userobj):
+    if not custom_logout_action(request, userobj):
         login(request, userobj)
     request.session["exit_users_pk"] = exit_users_pk
 

--- a/example/utils.py
+++ b/example/utils.py
@@ -51,3 +51,7 @@ def custom_login(request, user):
         rotate_token(request)
     except ImportError:
         pass
+
+
+# Same as custom_login, for backwards compatibility
+custom_logout = custom_login


### PR DESCRIPTION
So I've finally gotten around to setting things up!

Problem: this needs to be logged to the audit log, and the log for starting to impersonate (on `login_as_user`) needs to be different from the log for stopping to impersonate (on `su_logout`). This could also be solved by `login_as_user` sending a `su`-signal and `su_logout` sending an `unsu`-signal.

Also, #70 might be solved by adding a check that the user you su *to* is not a superuser in the custom login action, and *not* doing so in the custom logout action, which is also a problem I have: I don't want superusers to impersonate superusers. This should also fix my third problem: recursive su.

Might help in closing #70.