### PR TITLE
Add support for python 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 
 sudo: false
 python:
-  - "3.10"
+  - "3.10-dev"
   - "3.9"
   - "3.8"
   - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ language: python
 
 sudo: false
 python:
+  - "3.10"
   - "3.9"
   - "3.8"
   - "3.7"
   - "3.6"
 env:
+  - DJANGO="Django>=3.2,<3.3"
   - DJANGO="Django>=3.1,<3.2"
   - DJANGO="Django>=3,<3.1"
   - DJANGO="Django>=2.2,<2.3"

--- a/django_su/utils.py
+++ b/django_su/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import warnings
-import collections
+from collections.abc import Callable
 
 from django.conf import settings
 from django.utils.module_loading import import_string
@@ -16,7 +16,7 @@ def su_login_callback(user):
 
     func = getattr(settings, 'SU_LOGIN_CALLBACK', None)
     if func is not None:
-        if not isinstance(func, collections.Callable):
+        if not isinstance(func, Callable):
             func = import_string(func)
         return func(user)
     return user.has_perm('auth.change_user')
@@ -27,7 +27,7 @@ def custom_login_action(request, user):
     if func is None:
         return False
 
-    if not isinstance(func, collections.Callable):
+    if not isinstance(func, Callable):
         func = import_string(func)
     func(request, user)
 


### PR DESCRIPTION
Hi @adamcharnock and thank you for all your work on this project. We use it, our team loves it, and I'm excited to have a chance to contribute :)

This pull request adds support for python 3.10 by changing `collections.Callable` to `collections.abc.Callable`. `collections.Callable` was deprecated in 3.3 and removed in 3.10. See the note from the python documentation below:

> Deprecated since version 3.3, will be removed in version 3.10: Moved Collections Abstract Base Classes to the collections.abc module. For backwards compatibility, they continue to be visible in this module through Python 3.9.
https://docs.python.org/3.9/library/collections.html

This PR also adds Django 3.2 to the CI test environments.

Here is a link to the build passing on travis on my fork: https://app.travis-ci.com/github/marknotfound/django-su/builds/240260937