### PR TITLE
gh-actions: remove ajax-selects fork install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,12 +77,6 @@ jobs:
            pip install psycopg2==2.8.6
            pip install codecov
 
-      - name: Django 4.1 compatible version of ajax_selects
-        if: ${{ matrix.DJANGO_VERSION }} == '4.0'
-        run: |
-              # remove this once https://github.com/crucialfelix/django-ajax-selects/pull/289 is merged
-              pip uninstall -y django-ajax-selects
-              pip install git+https://github.com/andyzickler/django-ajax-selects@remove-default-app-config
       - name: Testing
         run: PYTHONPATH=`pwd` python -W error::DeprecationWarning -m coverage run --source django_su ./example/manage.py test
       - name: upload coverage

--- a/django_su/forms.py
+++ b/django_su/forms.py
@@ -10,7 +10,6 @@ User = get_user_model()
 
 
 class UserSuForm(forms.Form):
-
     username_field = getattr(User, "USERNAME_FIELD", None)
 
     user = forms.ModelChoiceField(

--- a/example/lookups.py
+++ b/example/lookups.py
@@ -10,7 +10,6 @@ from django_su import get_user_model
 
 @register("django_su")
 class UsersLookup(LookupChannel):
-
     model = get_user_model()
 
     def get_query(self, q, request):

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,8 +10,10 @@ universal = 1
 [flake8]
 max-line-length = 110
 ignore =
-   I202, # additional newline in imports
-   W503, # line break before binary operator
+   # additional newline in imports
+   I202,
+   # line break before binary operator
+   W503,
 exclude =
    *migrations/*,
 	docs/,


### PR DESCRIPTION
since the PR [django-ajax-selects/289](https://github.com/crucialfelix/django-ajax-selects/pull/289) has been merged we should be able test with Django >= 4 with mainline version of `django-ajax-selects`.